### PR TITLE
Fix receiver script ALPHA bug

### DIFF
--- a/Mesh/Avatar Roth/Release/Scripts/ro2_feet_receiver.lsl
+++ b/Mesh/Avatar Roth/Release/Scripts/ro2_feet_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);

--- a/Mesh/Avatar Roth/Release/Scripts/ro2_hand_receiver.lsl
+++ b/Mesh/Avatar Roth/Release/Scripts/ro2_hand_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);

--- a/Mesh/Avatar Roth/Release/Scripts/ro2_head_receiver.lsl
+++ b/Mesh/Avatar Roth/Release/Scripts/ro2_head_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);

--- a/Mesh/Avatar Ruth/Release/Scripts/ru2_feet_receiver.lsl
+++ b/Mesh/Avatar Ruth/Release/Scripts/ru2_feet_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);

--- a/Mesh/Avatar Ruth/Release/Scripts/ru2_hand_receiver.lsl
+++ b/Mesh/Avatar Ruth/Release/Scripts/ru2_hand_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);

--- a/Mesh/Avatar Ruth/Release/Scripts/ru2_head_receiver.lsl
+++ b/Mesh/Avatar Ruth/Release/Scripts/ru2_head_receiver.lsl
@@ -65,7 +65,7 @@ default
                             }
 
                         }
-                    } else if (command = "ALPHA")
+                    } else if (command == "ALPHA")
                     {
                         string prim2change = llStringTrim(llToUpper(llList2String(msglist, 1)), STRING_TRIM);
                         integer face2change = llList2Integer(msglist, 2);


### PR DESCRIPTION
The check for an ALPHA command in the feet, hands and head
receiver scripts for both Roth and Ruth incorrectly accepted
anything as an ALPHA command since the expression in the
if was actually an assignment (command = "ALPHA") which is
true.

This becomes noticable when an additional else is appended to the
if/else chain.

This bug also occurs in the following scripts in the Contrib
and PRevios Release directories.  I did not fix these as I did
not want to change anyone's scripts out from under them, but will
do so if folks want me to.

Contrib/Elenia Boucher/r2_feet_receiver.lsl
Contrib/Elenia Boucher/r2_hand_receiver.lsl
Contrib/Fred Beckhusen/r2_feet_receiver.lsl
Contrib/Fred Beckhusen/r2_hand_receiver.lsl
Contrib/Mike Dickson/r2_feet_receiver.lsl
Contrib/Mike Dickson/r2_hand_receiver.lsl
Contrib/Sundance Haiku/Scripts/r2_feet_receiver.lsl
Contrib/Sundance Haiku/Scripts/r2_hand_receiver.lsl
LSLScripts/HUD/Ruth/Previous Release/r2_feet_receiver.lsl
LSLScripts/HUD/Ruth/Previous Release/r2_hand_receiver.lsl